### PR TITLE
Implement recursive folder listing for image folder select

### DIFF
--- a/owlimg/owlimg.php
+++ b/owlimg/owlimg.php
@@ -25,6 +25,7 @@ class PlgFieldsOwlimg extends FieldsListPlugin
 		$fieldNode->setAttribute('directory', 'images/');
 		$fieldNode->setAttribute('hide_default', true);
 		$fieldNode->setAttribute('hide_none', true);
+		$fieldNode->setAttribute('recursive', true);
 
 		return $fieldNode;
 	}


### PR DESCRIPTION
This allows a user to select lower level sub-folders of the base folder, which is fixed as 'images/'.
Enables users to better structure their image folders for the images used by the plugin.