### PR TITLE
Remove cmd filter on input to fix collapsing css classes

### DIFF
--- a/owlimg/params/owlimg.xml
+++ b/owlimg/params/owlimg.xml
@@ -8,7 +8,6 @@
 				type="text"
 				label="PLG_FIELDS_OWLIMG_CUSTOMCLASS"
 				desc="PLG_FIELDS_OWLIMG_CUSTOMCLASS_DESC"
-				filter="cmd"
 				default="myowl"
 			/>
 


### PR DESCRIPTION
The cmd filter has the effect of collapsing css classes when multiple are entered.  You may argue that only one is needed here but this is not expected behaviour on custom css classs fields in Joomla.